### PR TITLE
Feature tap zone

### DIFF
--- a/ToTheTop/AppDelegate.swift
+++ b/ToTheTop/AppDelegate.swift
@@ -11,8 +11,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     window.backgroundColor = NSColor.green
     window.setFrameOrigin(point)
-    window.makeKeyAndOrderFront(nil)
     window.ignoresMouseEvents = true
+    window.orderFront(nil)
 
     self.window = window
   }

--- a/ToTheTop/AppDelegate.swift
+++ b/ToTheTop/AppDelegate.swift
@@ -14,6 +14,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     window.ignoresMouseEvents = true
     window.orderFront(nil)
 
+    NSEvent.addGlobalMonitorForEvents(matching: .leftMouseUp) { (event) in
+      guard window.frame.contains(event.locationInWindow) else {
+        return
+      }
+    }
+
     self.window = window
   }
 }

--- a/ToTheTop/AppDelegate.swift
+++ b/ToTheTop/AppDelegate.swift
@@ -12,6 +12,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     window.backgroundColor = NSColor.green
     window.setFrameOrigin(point)
     window.makeKeyAndOrderFront(nil)
+    window.ignoresMouseEvents = true
 
     self.window = window
   }

--- a/ToTheTop/Info.plist
+++ b/ToTheTop/Info.plist
@@ -22,6 +22,8 @@
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>LSUIElement</key>
+	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2017 Christoffer Winterkvist. All rights reserved.</string>
 	<key>NSMainNibFile</key>

--- a/ToTheTop/Window.swift
+++ b/ToTheTop/Window.swift
@@ -10,7 +10,6 @@ class Window: NSWindow {
               backing: .buffered,
               defer: false)
 
-    styleMask = .borderless
     level = Int(CGWindowLevelForKey(CGWindowLevelKey.overlayWindow))
   }
 }


### PR DESCRIPTION
This PR configures the view to not gain focus when you tap it. It does this by setting `.ignoresMouseEvents` to `true` on the window.

It also configures the plist to set the application to be a menu based application. This way the window will not steal focus.

Last but not least. To be able to still capture the mouse click event, the application registers a global monitor of the `.leftMouseUp` event.